### PR TITLE
feat(homepage): make login URL environment-dependent

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "watch": "sass src/css:dist/css --watch --load-path=src/css --load-path=node_modules",
     "watch:dv": "sass src/css/dv-custom.scss:dist/css/dv-custom.css --watch --load-path=src/css --load-path=node_modules",
     "dev": "vite",
-    "build:prod": "cp src/assets/logos/logo-prod.svg src/assets/logo.svg; rm -rf ./dist; sass src/css:dist/css --style=compressed --load-path=src/css --load-path=node_modules --no-source-map; vite build",
-    "build:pprd": "cp src/assets/logos/logo-pprd.svg src/assets/logo.svg; rm -rf ./dist; sass src/css:dist/css --style=compressed --load-path=src/css --load-path=node_modules --no-source-map; vite build",
+    "build:prod": "cp src/assets/logos/logo-prod.svg src/assets/logo.svg; rm -rf ./dist; sass src/css:dist/css --style=compressed --load-path=src/css --load-path=node_modules --no-source-map; vite build --mode prod",
+    "build:pprd": "cp src/assets/logos/logo-pprd.svg src/assets/logo.svg; rm -rf ./dist; sass src/css:dist/css --style=compressed --load-path=src/css --load-path=node_modules --no-source-map; vite build --mode pprd",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,8 @@
 <script setup>
 
 import {computed, ref} from 'vue'
+
+const loginUrl = import.meta.env.VITE_LOGIN_URL
 import '../dist/css/index.css';
 import Logo from './assets/logo.svg?component';
 import DVLogofull from './assets/dv-logo.svg?component';
@@ -187,7 +189,7 @@ const formatDate = (isoDate) => {
                     <Logo style="height:2.5em"/>
                 </a>
                 <div class="mt-4 mt-sm-0">
-                    <a href="https://data.sciencespo.fr/loginpage.xhtml" class="grey-link text-uppercase"
+                    <a :href="loginUrl" class="grey-link text-uppercase"
                        v-html="translation.login"></a>
                     <a href="#" @click.prevent="toggleLanguage"
                        class="text-uppercase language-chooser ml-3 ml-sm-5 red-box"


### PR DESCRIPTION
  Use Vite build modes (.env.prod / .env.pprd) to inject the correct
  login URL at build time, matching the existing logo strategy